### PR TITLE
Resolved the error of 1:N socket responding with error when connecting with first device.

### DIFF
--- a/src/main/scala/tilelink/TLSocket1_N.scala
+++ b/src/main/scala/tilelink/TLSocket1_N.scala
@@ -19,6 +19,11 @@ class TLSocket1_N(N: Int)(implicit val conf: TLConfiguration) extends Module {
   // the tl_err_d_i takes the input from the error responder and sends it to the host output tl_h_o
   val tl_err_d_i = Wire(Flipped(new TL_D2H))
 
+  // by default connecting the response with the error bundle
+  // this would be connected with the correct device according to dev_sel
+  // if dev_sel does not match any device than it will remain connected with this error bundle.
+  io.tl_h_o <> tl_err_d_i
+
   for(i <- 0 until N) {
     io.tl_d_o(i).a_valid := io.tl_h_i.a_valid && (io.dev_sel === i.asUInt)
     io.tl_d_o(i).a_opcode := io.tl_h_i.a_opcode
@@ -47,11 +52,10 @@ class TLSocket1_N(N: Int)(implicit val conf: TLConfiguration) extends Module {
       io.tl_h_o.d_sink := io.tl_d_i(id).d_sink
       io.tl_h_o.d_data := io.tl_d_i(id).d_data
       io.tl_h_o.d_error := io.tl_d_i(id).d_error
-    } .otherwise {
-      // if dev_sel does not match any device then wire the output with error responder device
-      io.tl_h_o <> tl_err_d_i
     }
   }
+
+
 
   tl_err_h_o.a_valid := io.tl_h_i.a_valid && (io.dev_sel === N.asUInt)
   tl_err_h_o.a_opcode := io.tl_h_i.a_opcode


### PR DESCRIPTION
This PR resolves #19 when the 1:N socket was connecting the response with the error responder bundle even though the `dev_sel` was selecting the correct device.